### PR TITLE
fix Get-NinjaCustomer -Name and some other stuff

### DIFF
--- a/Sources/Customer_Management.psm1
+++ b/Sources/Customer_Management.psm1
@@ -13,21 +13,52 @@ Function Get-NinjaCustomer {
 
     #>
 
-    PARAM
+    [CmdletBinding(DefaultParameterSetName='AllCustomers', 
+                    SupportsShouldProcess=$true, 
+                    PositionalBinding=$false,
+                    HelpUri = 'https://github.com/MaxAnderson95/PoSHNinjaRMM-Management',
+                    ConfirmImpact='Medium')]
+    [Alias()]
+    Param
     (
-        [Parameter]
+        # Param1 help description
+        [Parameter(ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true, 
+                   Position=0,
+                   ParameterSetName='CustomerID')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [Alias("ID")] 
         [Int]$CustomerID,
 
-        [Parameter]
-        [String]$CustomerName
-    )
+        # Returns the customer from a list that includes this PARAM
+        [Parameter(ParameterSetName='CustomerName')]
+        [ValidateNotNullOrEmpty()]
+        [AllowEmptyString()]
+        [Alias("Name")] 
+        [String]$CustomerName,
 
+        # Whether to return all customers
+        [Parameter(ParameterSetName='AllCustomers')]
+        [Alias("All")] 
+        [switch]$AllCustomers=$true
+
+    )
+    
     Begin
     {
+        Write-Verbose -Message "Parameter Set name being used is $($PSCmdlet.ParameterSetName)"
+        Write-Debug "Provided Parameter values are"    
+        Write-Debug "CustomerID:$CustomerID"
+        Write-Debug "CustomerName:$CustomerName"
+        Write-Debug "All Customers: $AllCustomers"
+        
         #Define the AccessKeyID and SecretAccessKeys
         Try 
         {
             $Keys = Get-NinjaAPIKeys
+            Write-Debug "Using Nija API Keys: "
+            Write-Debug $Keys
         } 
         
         Catch 
@@ -36,26 +67,13 @@ Function Get-NinjaCustomer {
         }
         
         #Determine if the input is CustomerID or no Customer entered (looking for list of all)
-        If ($CustomerID) 
-        {
-            $Choice = "CustomerID"
-        }
-
-        If ($CustomerName)
-        {
-            $Choice = "CustomerName"
-        }
-        
-        else 
-        {
-            $Choice = "None"
-        }
+        #$PSCmdlet.ParameterSetName
     }
     
 
     Process
     {
-        Switch ($Choice) {
+        Switch ($PSCmdlet.ParameterSetName) {
             "CustomerID" 
             {
                 $Header = New-NinjaRequestHeader -HTTPVerb GET -Resource /v1/customers/$CustomerID -AccessKeyID $Keys.AccessKeyID -SecretAccessKey $Keys.SecretAccessKey
@@ -65,11 +83,14 @@ Function Get-NinjaCustomer {
 
             "CustomerName"
             {
-                
+                #This just pullls the full list and returns only the matching entry. I'm not warning here since when it is recursively called it will warn then  
+                Write-Verbose -Message "Recursively calling AllCustomers and returns only the matching entry from that"
+                $Rest = Get-NinjaCustomer | Where-Object -Property Name -Like "*$CustomerName*"
             }
 
-            "None" 
+            "AllCustomers" 
             {
+                Write-Warning -Message "This uses a List API and is rate limited to 10 requests per 10 minutes by Ninja"
                 $Header = New-NinjaRequestHeader -HTTPVerb GET -Resource /v1/customers -AccessKeyID $Keys.AccessKeyID -SecretAccessKey $Keys.SecretAccessKey
 
                 $Rest = Invoke-RestMethod -Method GET -Uri "https://api.ninjarmm.com/v1/customers" -Headers $Header


### PR DESCRIPTION
Fill Get-NinjaCustomer -Name parameter

Added paramter sets. It now allows you to use either ID, Name, All, or no params (no params fetchs all still). You cannot specify two different types at once
added some aliases as well for params
added some loging